### PR TITLE
Update CachingDateFormatter.java

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/util/CachingDateFormatter.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/util/CachingDateFormatter.java
@@ -68,10 +68,10 @@ public class CachingDateFormatter {
     public final String format(long now) {
         CacheTuple localCacheTuple = atomicReference.get();
         CacheTuple oldCacheTuple = localCacheTuple;
-
+        DateTimeFormatter dtf1 = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.of("UTC"));
         if (now != localCacheTuple.lastTimestamp) {
             Instant instant = Instant.ofEpochMilli(now);
-            String result = dtf.format(instant);
+            String result = dtf1.format(instant);
             localCacheTuple = new CacheTuple(now, result);
             // allow a single thread to update the cache reference
             atomicReference.compareAndSet(oldCacheTuple, localCacheTuple);


### PR DESCRIPTION
PR Overview:
_________________________________________________________________________________________________________
This PR fixes the flaky/non-deterministic behavior of the following test because it assumes the zone in the  DateTimeFormatter.

[ch.qos.logback.core.rolling.helper.SizeAndTimeBasedArchiveRemoverTest](https://github.com/qos-ch/logback/blob/master/logback-core/src/test/java/ch/qos/logback/core/rolling/helper/SizeAndTimeBasedArchiveRemoverTest.java)


Test Overview:
_________________________________________________________________________________________________________
The test above uses the [SizeAndTimeBasedArchiveRemover](https://github.com/njain2208/logback/blob/flaky-test-fix/logback-core/src/test/java/ch/qos/logback/core/rolling/helper/SizeAndTimeBasedArchiveRemoverTest.java) object, which uses the descendingSort method, this method makes an internal call to the [Format](https://github.com/njain2208/logback/blob/5cc0d2faa62443b14272485822aace48a765b824/logback-core/src/main/java/ch/qos/logback/core/util/CachingDateFormatter.java#L68) method in the [CachingDateFormatter.java](https://github.com/njain2208/logback/blob/flaky-test-fix/logback-core/src/main/java/ch/qos/logback/core/util/CachingDateFormatter.java) file where the problem lies.

You can reproduce the issue by running the following commands -

mvn install -pl logback-core -am -DskipTests
mvn test -pl logback-core -Dtest=ch.qos.logback.core.rolling.helper.SizeAndTimeBasedArchiveRemoverTest
 mvn -pl logback-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=ch.qos.logback.core.rolling.helper.SizeAndTimeBasedArchiveRemoverTest

Within the format class, the zone is initially set to null. However, when I ran the rest on the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) software it introduced variability in the test seed, causing the zone to deviate from UTC. Consequently, the date value shifts from "smoke-1970-01-01-1.gz" to "smoke-1969-12-31-(\d+).gz," resulting in test failures.
This flakiness was identified by the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) created by the researchers of UIUC.

Fix:
_________________________________________________________________________________________________________
To fix the issue I decided to explicitly set the zone to UTC to DateTimeFormatter in the format() method in the [CachingDateFormatter.java](https://github.com/njain2208/logback/blob/flaky-test-fix/logback-core/src/main/java/ch/qos/logback/core/util/CachingDateFormatter.java) file.

https://github.com/njain2208/logback/blob/5cc0d2faa62443b14272485822aace48a765b824/logback-core/src/main/java/ch/qos/logback/core/util/CachingDateFormatter.java#L71-L78

Failures:
_________________________________________________________________________________________________________
Nondex error:
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running ch.qos.logback.core.rolling.helper.SizeAndTimeBasedArchiveRemoverTest
smoke-1969-12-31-(\d+).gz
smoke-1969-12-31-(\d+).gz
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.261 s <<< FAILURE! - in ch.qos.logback.core.rolling.helper.SizeAndTimeBasedArchiveRemoverTest
[ERROR] ch.qos.logback.core.rolling.helper.SizeAndTimeBasedArchiveRemoverTest.badFilenames  Time elapsed: 0.181 s
[ERROR] ch.qos.logback.core.rolling.helper.SizeAndTimeBasedArchiveRemoverTest.smoke  Time elapsed: 0.01 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: array contents differ at index [0], expected: </tmp/smoke-1970-01-01-1.gz> but was: </tmp/smoke-1970-01-01-0.gz>
        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at org.junit.jupiter.api.AssertArrayEquals.failArraysNotEqual(AssertArrayEquals.java:440)
        at org.junit.jupiter.api.AssertArrayEquals.assertArrayElementsEqual(AssertArrayEquals.java:389)
        at org.junit.jupiter.api.AssertArrayEquals.assertArrayEquals(AssertArrayEquals.java:346)
        at org.junit.jupiter.api.AssertArrayEquals.assertArrayEquals(AssertArrayEquals.java:159)
        at org.junit.jupiter.api.AssertArrayEquals.assertArrayEquals(AssertArrayEquals.java:155)
        at org.junit.jupiter.api.Assertions.assertArrayEquals(Assertions.java:1453)
        at ch.qos.logback.core@1.4.12-SNAPSHOT/ch.qos.logback.core.rolling.helper.SizeAndTimeBasedArchiveRemoverTest.smoke(SizeAndTimeBasedArchiveRemoverTest.java:31)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
        at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
        at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
        at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147)
        at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
        at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
        at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
        at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
        at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:217)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:213)
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:138)
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:68)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
        at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
        at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
        at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
        at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
        at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
        at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:147)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:127)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:90)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:55)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:102)
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:54)
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
        at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
        at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:55)
        at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:223)
        at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:175)
        at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:139)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:456)
        at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:169)
        at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:595)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:581)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   SizeAndTimeBasedArchiveRemoverTest.smoke:31 array contents differ at index [0], expected: </tmp/smoke-1970-01-01-1.gz> but was: </tmp/smoke-1970-01-01-0.gz>
[INFO] 
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
```

